### PR TITLE
Activity Heartbeats and Cancellation

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,10 +43,10 @@ A collection of common mistakes made when using [Temporal](https://temporal.io) 
 - Not setting a workflow timeout (they'll run for 10 years!)
 
 ## Cancellation
-- Expecting activities to observe workflow cancellation automatically
 - Assuming activity cancellation means workflow cancellation
 - Not using ParentClosePolicy when graceful cleanup on cancellation is needed in child workflows
 - Deadlocking when workflow cancelled (handle cancel signal)
+- Not sending heartbeats from activities you want to handle cancellation.
 
 ## Software Design
 - Not making activities idempotent (at least once execution semantic, even with max attempts == 1)


### PR DESCRIPTION
Subtle issue that you only find looking at [SDK docs](https://pkg.go.dev/go.temporal.io/sdk/workflow#ExecuteActivity) or in [community forums](https://community.temporal.io/t/when-a-workflow-is-cancelled-how-is-the-ongoing-execution-handled/62/3)

> You can cancel the pending activity using context(workflow.WithCancel(ctx)) and that will fail the activity with *CanceledError set as cause for *ActivityError. The context in the activity only becomes aware of the cancellation when a heartbeat is sent to the server. Since heartbeats may be batched internally, this could take up to the HeartbeatTimeout to appear or several minutes by default if that value is not set.